### PR TITLE
CVE-2017-15908

### DIFF
--- a/cves/CVE-2017-15908.yml
+++ b/cves/CVE-2017-15908.yml
@@ -59,7 +59,10 @@ description:
   In a function that handles the parsing of specific DNS packets there was a 
   non-terminating while loop caused by a continue statement that would cause any
   possible changes to the loop condition from happening. This infinite loop caused
-  a potential for DoS attacks against DNSSEC servers.
+  a potential for DoS attacks against services that made use of systemd-resolve to 
+  resolve DNS queries over DNSSEC. If a DNSSEC server were to be compromised and add
+  one of these NSEC packets to its responses, it could potentially crash any services
+  that attempt to resolve the response.
   
   The only packets that would cause this infinite loop are NSEC packets,
   which are part of DNSSEC, the DNS Security protocol. NSEC packets allow

--- a/cves/CVE-2017-15908.yml
+++ b/cves/CVE-2017-15908.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you 
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated. 
-curation_level: 0
+curation_level: 1
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that

--- a/cves/CVE-2017-15908.yml
+++ b/cves/CVE-2017-15908.yml
@@ -26,7 +26,7 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2017-10-20
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2017-10-25
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2017-10-26
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -56,6 +56,18 @@ description_instructions: |
   Your target audience is people just like you before you took any course in
   security
 description:
+  In a function that handles the parsing of specific DNS packets there was a 
+  non-terminating while loop caused by a continue statement that would cause any
+  possible changes to the loop condition from happening. This infinite loop caused
+  a potential for DoS attacks against DNSSEC servers.
+  
+  The only packets that would cause this infinite loop are NSEC packets,
+  which are part of DNSSEC, the DNS Security protocol. NSEC packets allow
+  a DNS server to provide authenticated denial of the existence of a given record
+  on the server.
+
+  The fix was to modify the loop from a while loop to a for loop. This removed the potential
+  for an infinite loop.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -79,8 +91,8 @@ fixes_instructions: |
 
   Place any notes you would like to make in the notes field.
 fixes:
-- commit: 8aeadf3052a2130b88d5bccf5439890e1034f28d
-  note: https://github.com/systemd/systemd/commit/8aeadf3052a2130b88d5bccf5439890e1034f28d
+- commit: 9f939335a07085aa9a9663efd1dca06ef6405d62
+  note: https://github.com/systemd/systemd/commit/9f939335a07085aa9a9663efd1dca06ef6405d62
 - commit:
   note:
 vcc_instructions: |
@@ -97,7 +109,7 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
 - commit: 50f1e641a93cacfc693b0c3d300bee5df0c8c460
-  :note: Discovered automatically by archeogit.
+  :note: This bug existed in production for 2 years!
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -120,10 +132,16 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
+  code: false
   code_answer:
-  fix:
+    The PR was almost entirely brand new code. While some of the code that was 
+    added, namely utility classes, got unit tests, the actual functionality that
+    the PR aimed to implement did not have any unit tests written for it.
+  fix: false
   fix_answer:
+    The PR was a total of three lines. Replacing the while loop with a for loop, 
+    and moving the increments/mutations into the for loop header. It also seems as
+    though this entire file lacks standalone tests.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -139,9 +157,11 @@ discovered:
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
   answer:
-  automated:
-  contest:
-  developer:
+    The vulnerability was found by two researchers at Sogeti, which is an IT consultancy firm.
+    The researchers did not detail how they found the bug, but they do provide steps to reproduce it.
+  automated: false
+  contest: false
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -158,8 +178,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
+  note: true
   answer:
+    Any unit test that sent an NSEC record through this function would 
+    have hit a timeout since there's an infinite loop. This would flag
+    that there's an issue present.
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -176,8 +199,11 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: 
+    There's no mention of a specification violation on any of the related resources.
+    The bug was really just a minor implementation error, but if the code worked it 
+    would have followed the correct RFC for NSEC records.
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in? These are subsystems WITHIN systemd
@@ -206,8 +232,9 @@ subsystem:
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
 
-  name:
+  name: resolve
   note:
+    Resolve seems to be the folder for parsing and resolving DNS packets.
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -231,8 +258,11 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: 
+    This feature is not related to internationalization at all. 
+    Perhaps there could be an issue with NSEC records in non-standard
+    encodings, but that is not relevant to this particular bug.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -246,8 +276,10 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
+  answer: false
   note:
+    This feature only dealt with the parsing of a packet, so nothing about it
+    should interact with sandboxing. It's a Denial of Service vulnerability.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -258,8 +290,9 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: 
+    This vulnerability only occurred in a single process.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -286,9 +319,12 @@ discussion:
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
 
-  discussed_as_security:
-  any_discussion:
-  note:
+  discussed_as_security: false
+  any_discussion: false
+  note: 
+    The only real discussion was on the report, where multiple people mentioned
+    that the vulnerability was a very good find, and thanked the researchers that found it.
+    https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1725351
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for 
@@ -301,8 +337,8 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: false
+  note: Outside of the PR being merged, there was no specific vouching.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports? 
@@ -316,9 +352,12 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: false
+  stacktrace_with_fix: false
+  note: 
+    The bug report details the part of the code that has the bug, but no stacktrace.
+    This is likely because the vulnerability was DoS, so the server would just fizzle out
+    and get restarted by WatchDog after a set amount of time.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -337,8 +376,8 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: The condition on the while loop wasn't forgotten, per se, but it was ineffective.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of 
@@ -350,8 +389,10 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: 
+    The bug boiled down to a continue statement allowing execution to skip
+    the increment in a while loop
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -368,37 +409,37 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
+    applies: false
     note:
   least_privilege:
-    applies:
+    applies: false
     note:
   frameworks_are_optional:
-    applies:
+    applies: false
     note:
   native_wrappers:
-    applies:
+    applies: false
     note:
   distrust_input:
-    applies:
+    applies: false
     note:
   security_by_obscurity:
-    applies:
+    applies: false
     note:
   serial_killer:
-    applies:
+    applies: false
     note:
   environment_variables:
-    applies:
+    applies: false
     note:
   secure_by_default:
-    applies:
+    applies: false
     note:
   yagni:
-    applies:
+    applies: false
     note:
   complex_inputs:
-    applies:
+    applies: true
     note:
 mistakes:
   question: |
@@ -430,6 +471,15 @@ mistakes:
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
   answer:
+    This really seemed like a slip up on an otherwise excellent addition that was 
+    made potentially much worse by the poor design choice of lacking unit tests.
+    
+    The slip up was having a while loop and a continue statement that allowed the 
+    while to run infinitely.
+
+    The design failure was not adequately testing the core functionality of the
+    pull request. The entire feature was adding NSEC capabilities to systemd, but
+    the parsing of NSEC records was not thoroughly tested.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -445,7 +495,7 @@ CWE_instructions: |
     CWE: ["123", "456"] # this is ok
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
-CWE:
+CWE: ["571", "835"]
 CWE_note:
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.

--- a/cves/CVE-2017-15908.yml
+++ b/cves/CVE-2017-15908.yml
@@ -64,9 +64,9 @@ description:
   one of these NSEC packets to its responses, it could potentially crash any services
   that attempt to resolve the response.
   
-  The only packets that would cause this infinite loop are NSEC packets,
-  which are part of DNSSEC, the DNS Security protocol. NSEC packets allow
-  a DNS server to provide authenticated denial of the existence of a given record
+  The only packets that would cause this infinite loop are so called NSEC packets,
+  which are part of DNSSEC. DNSSEC stands for Domain Name Service Security Extensions. NSEC, which stands for Next Secure Record, packets allow
+  a DNSSEC server to provide authenticated denial of the existence of a given record
   on the server.
 
   The fix was to modify the loop from a while loop to a for loop. This removed the potential
@@ -85,7 +85,7 @@ bugs_instructions: |
 
   For systemd, this is typically their GitHub issues, but could also include 
   bugs from other databases. Put a URL instead of a single number.
-bugs: []
+bugs: [https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1725351]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -120,7 +120,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: +9
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?

--- a/cves/CVE-2017-15908.yml
+++ b/cves/CVE-2017-15908.yml
@@ -162,7 +162,7 @@ discovered:
   automated: false
   contest: false
   developer: false
-autodiscoverable:
+autodiscoverable: 
   instructions: |
     Is it plausible that a fully automated tool could have discovered
     this? These are tools that require little knowledge of the domain,
@@ -178,11 +178,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note: true
-  answer:
+  note: 
     Any unit test that sent an NSEC record through this function would 
     have hit a timeout since there's an infinite loop. This would flag
     that there's an issue present.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX


### PR DESCRIPTION
In systemd 223 through 235, a remote DNS server can respond with a custom crafted DNS NSEC resource record to trigger an infinite loop in the dns_packet_read_type_window() function of the 'systemd-resolved' service and cause a DoS of the affected service.