### PR TITLE
CVE-2013-4393

### DIFF
--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -171,10 +171,12 @@ discovered:
   answer: |
     This vulnerability was discovered long enough ago that the problem 
     report (if it was done on Git) is no longer on the repository. I found 
-    details for this vulnerability on the Red Hat bug reporting forums.
+    details for this vulnerability on the Red Hat bug reporting forums. It 
+    was originally reported by Jan Lieskovsky, but discovered by Florian 
+    Weimer from the Red Hat Product Security Team.
   automated: false
   contest: false
-  developer: nil
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -76,7 +76,7 @@ bugs_instructions: |
 
   For systemd, this is typically their GitHub issues, but could also include 
   bugs from other databases. Put a URL instead of a single number.
-bugs: [https://bugzilla.redhat.com/show_bug.cgi?id=859104]
+bugs: ["https://bugzilla.redhat.com/show_bug.cgi?id=859104"]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -26,7 +26,7 @@ reported_instructions: |
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2012-09-20
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2013-06-12
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2013-10-28
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -55,7 +55,13 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: The native journal protocol in systemd is responsible for 
+  parsing predefined log data into the program for testing purposes. Its original 
+  implementation introduced a vulnerability when combined with the previously 
+  existing logging functionality. Local users could make a maliciously-crafted 
+  file to force the logging module to block, causing later logging messages 
+  from systemd to not be recorded.
+
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -70,7 +76,7 @@ bugs_instructions: |
 
   For systemd, this is typically their GitHub issues, but could also include 
   bugs from other databases. Put a URL instead of a single number.
-bugs: []
+bugs: [https://bugzilla.redhat.com/show_bug.cgi?id=859104]
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -81,6 +87,11 @@ fixes_instructions: |
 fixes:
 - commit: 1dfa7e79a60de680086b1d93fcc3629b463f58bd
   note: Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
+  This fix makes it so predefined log data can only come from trusted logging 
+  directories in the Linux OS (such as /tmp/). This also means only people with 
+  the proper permissions to access files in those directories (who would also
+  be familiar with using them for the proper purposes) would be able to make use 
+  of the native logging protocol.
 - commit:
   note:
 vcc_instructions: |
@@ -97,13 +108,18 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
 - commit: 0153028ae379eb7c9a463c548ef73ea392c6cdb0
-  :note: Discovered automatically by archeogit.
+  :note: Discovered automatically by archeogit. Most likely not relevant- 
+  refactors native journal functionality out of original journald file and 
+  into its own.
 - commit: cbdca8525b4f36297cb9e5cb090a9648763ed1bf
-  :note: Discovered automatically by archeogit.
+  :note: Discovered automatically by archeogit. This commit improves 
+  functionality for searching journal entries for matching field-value pairs.
 - commit: b070e7f3c9ed680c821bd89d42506695f2438506
-  :note: Discovered automatically by archeogit.
+  :note: Discovered automatically by archeogit. This commit sets up 
+  functionality for reading user log files into the system.
 - commit: 18c7ed186be28800a2eeb37ad31c9c44480d3d9c
-  :note: Discovered automatically by archeogit.
+  :note: Discovered automatically by archeogit. This commit adds error handling 
+  for problems caused by user-given log files.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -126,10 +142,13 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: true
+  code_answer: There were unit tests for this subsystem, but they did not seem 
+  to account for the scenario surrounding the vulnerability.
+  fix: true
+  fix_answer: It looks like a unit test was modified with the fix for the 
+  vulnerability. It ensures that the journald subsystem does not enter an 
+  infinite blocking state when processing a very large piece of data.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -144,10 +163,12 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: This vulnerability was discovered long enough ago that the problem 
+  report (if it was done on Git) is no longer on the repository. I found 
+  details for this vulnerability on the Red Hat bug reporting forums.
+  automated: false
+  contest: false
+  developer: nil
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -164,8 +185,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: The native journal functionality requires log data files to be 
+  formatted in a specific manner, and then further purposely formatted to 
+  abuse the vulnerability in question. This is not automatable without 
+  specific subsystem knowledge.
+  answer: false
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -182,8 +206,9 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: None of the bug reports nor relevant commits mention any violation of 
+  specifications. This logging subsystem looks to be unique to systemd.
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in? These are subsystems WITHIN systemd
@@ -212,8 +237,9 @@ subsystem:
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
 
-  name:
-  note:
+  name: journald
+  note: Fairly straightforward- all the reports and included files reference 
+  this name accordingly.
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -221,10 +247,10 @@ interesting_commits:
     Use this to specify any commits you think are notable in some way, and
     explain why in the note.
   commits:
-  - commit:
-    note:
-  - commit:
-    note:
+  - commit: 505b6a61c22d5565e9308045c7b9bf79f7d0517e
+    note: This commit shows that there was some consideration for what could 
+    go wrong with the logging, when left up to the local user. This particular 
+    commit protects against potential log overflow exploits.
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -237,8 +263,10 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: This vulnerability happened entirely on the local level. Since no 
+  networking was involved, then it can be safely assumed that this only applies 
+  to English Linux platforms.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -252,8 +280,11 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: Though part of the vulnerability was related to poor path management, 
+  there was no place for the user to change the path of the input log files to 
+  something unexpected. To exploit the vulnerability, they would not need to 
+  change the source code's functionality.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -264,8 +295,10 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: This subsystem is responsible for parsing and creating logging data 
+  while systemd is running. This involves reading/writing information to 
+  relevant files.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -292,9 +325,12 @@ discussion:
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
 
-  discussed_as_security:
-  any_discussion:
-  note:
+  discussed_as_security: false
+  any_discussion: true
+  note: This vulnerability was patched relatively quickly. The only active 
+  dicussion thread I could find about the matter was the Red Hat bug report. 
+  The post got a reply after the bug had already been resolved. The discussion 
+  was a short one about which versions of systemd were affected.
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for 
@@ -307,8 +343,11 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: false
+  note: The commit history of the file in between the vulnerability being 
+  discovered and fixed only showed work from one person. A search of the 
+  commit comments between the release version tags showed no discussion on the 
+  matter.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports? 
@@ -322,9 +361,10 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: false
+  stacktrace_with_fix: false
+  note: No traces were provided in either the bug report or in a comment 
+  about the corresponding fix.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -343,8 +383,10 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: The main fix for the vulnerability involved adding a check when 
+  processing a native logging file (whether from user or systemd) to make 
+  sure that its absolute path was in a safe Linux OS location.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of 
@@ -356,8 +398,9 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: The method calls in the log file processing chain (after being kicked 
+  off by the fixed portion of code) remained entirely in the same order.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -374,37 +417,45 @@ lessons:
     If you think of another lesson we covered in class that applies here, feel
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
-    applies:
-    note:
+    applies: true
+    note: Even though the vulnerability was not severe enough to be actively 
+    abused, it was still a scenario that the developer of the native journal 
+    code did not account for, even while testing. They definitely should have 
+    added tests with invalid/malformed input files to make sure the error 
+    handling was graceful.
   least_privilege:
-    applies:
+    applies: false
     note:
   frameworks_are_optional:
-    applies:
+    applies: false
     note:
   native_wrappers:
-    applies:
+    applies: false
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: Similarly to the methods for achieving defense in depth, the 
+    assumption that user log files would be correct all the time was unsafe.
   security_by_obscurity:
-    applies:
+    applies: false
     note:
   serial_killer:
-    applies:
-    note:
+    applies: true
+    note: Serialization was a necessary risk for the sake of being able to 
+    properly test functionality in other parts of systemd. In an ideal world, 
+    the user would not need to manually specify and/or move around what log 
+    files are needed for testing.
   environment_variables:
-    applies:
+    applies: false
     note:
   secure_by_default:
-    applies:
+    applies: false
     note:
   yagni:
-    applies:
+    applies: false
     note:
   complex_inputs:
-    applies:
+    applies: false
     note:
 mistakes:
   question: |
@@ -435,7 +486,18 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: This vulnerability most likely came from a mistake in planning, which 
+  is totally valid for a project that grew as much as systemd. It seems that 
+  allowing the user to have some control over the logging subsystem was an 
+  afterthought, meaning that the original logging functionality was not 
+  adequately prepared to handle the extra complexity and error that comes 
+  with any user input. 
+  An ideal fix to the solution would have been eliminating 
+  the assumption in the preexisting logging system that all log messages would 
+  be formatted correctly. Despite that, restricting where logging input files 
+  are allowed to come from also works as a mitigation in this scenario, 
+  because it is unlikely that the average user would need to use the feature 
+  in the first place.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -451,10 +513,12 @@ CWE_instructions: |
     CWE: ["123", "456"] # this is ok
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
-CWE:
-CWE_note:
+CWE: 399
+CWE_note: Resource management error- there was a lack of handling for 
+gracefully continuing logging after error due to user input. In direct 
+relation to the fix, improper resource name/file restrictions also applies.
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.
   Must be under 30 characters. Optional.
-nickname:
+nickname: Journald Logging Clogging

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -93,8 +93,6 @@ fixes:
   the proper permissions to access files in those directories (who would also
   be familiar with using them for the proper purposes) would be able to make use 
   of the native logging protocol.
-- commit:
-  note:
 vcc_instructions: |
   The vulnerability-contributing commits.
 

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -86,7 +86,8 @@ fixes_instructions: |
   Place any notes you would like to make in the notes field.
 fixes:
 - commit: 1dfa7e79a60de680086b1d93fcc3629b463f58bd
-  note: Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
+  note: |
+  Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
   This fix makes it so predefined log data can only come from trusted logging 
   directories in the Linux OS (such as /tmp/). This also means only people with 
   the proper permissions to access files in those directories (who would also
@@ -486,7 +487,8 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer: This vulnerability most likely came from a mistake in planning, which 
+  answer: |
+  This vulnerability most likely came from a mistake in planning, which 
   is totally valid for a project that grew as much as systemd. It seems that 
   allowing the user to have some control over the logging subsystem was an 
   afterthought, meaning that the original logging functionality was not 

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you 
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated. 
-curation_level: 0
+curation_level: 1
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -19,14 +19,14 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you 
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated. 
-curation_level: '1'
+curation_level: 1
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date: 2012-09-20
+reported_date: '2012-09-20'
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date: 2013-06-12
+announced_date: '2013-06-12'
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date: 2013-10-28
+published_date: '2013-10-28'
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -19,7 +19,7 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you 
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated. 
-curation_level: 1
+curation_level: '1'
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -130,7 +130,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 11
+upvotes: 16
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -277,9 +277,9 @@ i18n:
     what your answer was.
   answer: false
   note: |
-    This vulnerability happened entirely on the local level. Since no 
-    networking was involved, then it can be safely assumed that this only applies 
-    to English Linux platforms.
+    This vulnerability happened entirely on the local level- no 
+    networking was involved. It can be safely assumed that this issue is independent 
+    of the Linux localization.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -362,9 +362,10 @@ vouch:
   answer: false
   note: |
     The commit history of the file in between the vulnerability being 
-    discovered and fixed only showed work from one person. A search of the 
-    commit comments between the release version tags showed no discussion on the 
-    matter.
+    discovered and fixed only showed work from one person, due to the history 
+    of the repository starting after the discovery and fix of the vulnerability. 
+    A search of the commit comments between the release version tags showed no 
+    discussion on the matter.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports? 

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -86,13 +86,13 @@ fixes_instructions: |
   Place any notes you would like to make in the notes field.
 fixes:
 - commit: 1dfa7e79a60de680086b1d93fcc3629b463f58bd
-  :note: |
-  Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
-  This fix makes it so predefined log data can only come from trusted logging 
-  directories in the Linux OS (such as /tmp/). This also means only people with 
-  the proper permissions to access files in those directories (who would also
-  be familiar with using them for the proper purposes) would be able to make use 
-  of the native logging protocol.
+  note: |
+    Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
+    This fix makes it so predefined log data can only come from trusted logging 
+    directories in the Linux OS (such as /tmp/). This also means only people with 
+    the proper permissions to access files in those directories (who would also
+    be familiar with using them for the proper purposes) would be able to make use 
+    of the native logging protocol.
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -107,18 +107,22 @@ vcc_instructions: |
   Place any notes you would like to make in the notes field.
 vccs:
 - commit: 0153028ae379eb7c9a463c548ef73ea392c6cdb0
-  :note: Discovered automatically by archeogit. Most likely not relevant- 
-  refactors native journal functionality out of original journald file and 
-  into its own.
+  :note: |
+    Discovered automatically by archeogit. Most likely not relevant- 
+    refactors native journal functionality out of original journald file and 
+    into its own.
 - commit: cbdca8525b4f36297cb9e5cb090a9648763ed1bf
-  :note: Discovered automatically by archeogit. This commit improves 
-  functionality for searching journal entries for matching field-value pairs.
+  :note: |
+    Discovered automatically by archeogit. This commit improves 
+    functionality for searching journal entries for matching field-value pairs.
 - commit: b070e7f3c9ed680c821bd89d42506695f2438506
-  :note: Discovered automatically by archeogit. This commit sets up 
-  functionality for reading user log files into the system.
+  :note: |
+    Discovered automatically by archeogit. This commit sets up 
+    functionality for reading user log files into the system.
 - commit: 18c7ed186be28800a2eeb37ad31c9c44480d3d9c
-  :note: Discovered automatically by archeogit. This commit adds error handling 
-  for problems caused by user-given log files.
+  :note: |
+    Discovered automatically by archeogit. This commit adds error handling 
+    for problems caused by user-given log files.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -142,12 +146,14 @@ unit_tested:
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
   code: true
-  code_answer: There were unit tests for this subsystem, but they did not seem 
-  to account for the scenario surrounding the vulnerability.
+  code_answer: |
+    There were unit tests for this subsystem, but they did not seem 
+    to account for the scenario surrounding the vulnerability.
   fix: true
-  fix_answer: It looks like a unit test was modified with the fix for the 
-  vulnerability. It ensures that the journald subsystem does not enter an 
-  infinite blocking state when processing a very large piece of data.
+  fix_answer: |
+    It looks like a unit test was modified with the fix for the 
+    vulnerability. It ensures that the journald subsystem does not enter an 
+    infinite blocking state when processing a very large piece of data.
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -162,9 +168,10 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer: This vulnerability was discovered long enough ago that the problem 
-  report (if it was done on Git) is no longer on the repository. I found 
-  details for this vulnerability on the Red Hat bug reporting forums.
+  answer: |
+    This vulnerability was discovered long enough ago that the problem 
+    report (if it was done on Git) is no longer on the repository. I found 
+    details for this vulnerability on the Red Hat bug reporting forums.
   automated: false
   contest: false
   developer: nil
@@ -184,10 +191,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note: The native journal functionality requires log data files to be 
-  formatted in a specific manner, and then further purposely formatted to 
-  abuse the vulnerability in question. This is not automatable without 
-  specific subsystem knowledge.
+  note: |
+    The native journal functionality requires log data files to be 
+    formatted in a specific manner, and then further purposely formatted to 
+    abuse the vulnerability in question. This is not automatable without 
+    specific subsystem knowledge.
   answer: false
 specification:
   instructions: |
@@ -205,8 +213,9 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note: None of the bug reports nor relevant commits mention any violation of 
-  specifications. This logging subsystem looks to be unique to systemd.
+  note: |
+    None of the bug reports nor relevant commits mention any violation of 
+    specifications. This logging subsystem looks to be unique to systemd.
   answer: false
 subsystem:
   question: |
@@ -237,8 +246,9 @@ subsystem:
         name: subsystemA # also ok
 
   name: journald
-  note: Fairly straightforward- all the reports and included files reference 
-  this name accordingly.
+  note: |
+    Fairly straightforward- all the reports and included files reference 
+    this name accordingly.
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -247,9 +257,10 @@ interesting_commits:
     explain why in the note.
   commits:
   - commit: 505b6a61c22d5565e9308045c7b9bf79f7d0517e
-    note: This commit shows that there was some consideration for what could 
-    go wrong with the logging, when left up to the local user. This particular 
-    commit protects against potential log overflow exploits.
+    note: |
+      This commit shows that there was some consideration for what could 
+      go wrong with the logging, when left up to the local user. This particular 
+      commit protects against potential log overflow exploits.
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization
@@ -263,9 +274,10 @@ i18n:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: false
-  note: This vulnerability happened entirely on the local level. Since no 
-  networking was involved, then it can be safely assumed that this only applies 
-  to English Linux platforms.
+  note: |
+    This vulnerability happened entirely on the local level. Since no 
+    networking was involved, then it can be safely assumed that this only applies 
+    to English Linux platforms.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -280,10 +292,11 @@ sandbox:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: false
-  note: Though part of the vulnerability was related to poor path management, 
-  there was no place for the user to change the path of the input log files to 
-  something unexpected. To exploit the vulnerability, they would not need to 
-  change the source code's functionality.
+  note: |
+    Though part of the vulnerability was related to poor path management, 
+    there was no place for the user to change the path of the input log files to 
+    something unexpected. To exploit the vulnerability, they would not need to 
+    change the source code's functionality.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -295,9 +308,10 @@ ipc:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: true
-  note: This subsystem is responsible for parsing and creating logging data 
-  while systemd is running. This involves reading/writing information to 
-  relevant files.
+  note: |
+    This subsystem is responsible for parsing and creating logging data 
+    while systemd is running. This involves reading/writing information to 
+    relevant files.
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -326,10 +340,11 @@ discussion:
 
   discussed_as_security: false
   any_discussion: true
-  note: This vulnerability was patched relatively quickly. The only active 
-  dicussion thread I could find about the matter was the Red Hat bug report. 
-  The post got a reply after the bug had already been resolved. The discussion 
-  was a short one about which versions of systemd were affected.
+  note: |
+    This vulnerability was patched relatively quickly. The only active 
+    dicussion thread I could find about the matter was the Red Hat bug report. 
+    The post got a reply after the bug had already been resolved. The discussion 
+    was a short one about which versions of systemd were affected.
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for 
@@ -343,10 +358,11 @@ vouch:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
   answer: false
-  note: The commit history of the file in between the vulnerability being 
-  discovered and fixed only showed work from one person. A search of the 
-  commit comments between the release version tags showed no discussion on the 
-  matter.
+  note: |
+    The commit history of the file in between the vulnerability being 
+    discovered and fixed only showed work from one person. A search of the 
+    commit comments between the release version tags showed no discussion on the 
+    matter.
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports? 
@@ -362,8 +378,9 @@ stacktrace:
     what your answer was.
   any_stacktraces: false
   stacktrace_with_fix: false
-  note: No traces were provided in either the bug report or in a comment 
-  about the corresponding fix.
+  note: | 
+    No traces were provided in either the bug report or in a comment 
+    about the corresponding fix.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -383,9 +400,10 @@ forgotten_check:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: true
-  note: The main fix for the vulnerability involved adding a check when 
-  processing a native logging file (whether from user or systemd) to make 
-  sure that its absolute path was in a safe Linux OS location.
+  note: |
+    The main fix for the vulnerability involved adding a check when 
+    processing a native logging file (whether from user or systemd) to make 
+    sure that its absolute path was in a safe Linux OS location.
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of 
@@ -398,8 +416,9 @@ order_of_operations:
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
   answer: false
-  note: The method calls in the log file processing chain (after being kicked 
-  off by the fixed portion of code) remained entirely in the same order.
+  note: |
+    The method calls in the log file processing chain (after being kicked 
+    off by the fixed portion of code) remained entirely in the same order.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -417,11 +436,12 @@ lessons:
     free to give it a small name and add one in the same format as these.
   defense_in_depth:
     applies: true
-    note: Even though the vulnerability was not severe enough to be actively 
-    abused, it was still a scenario that the developer of the native journal 
-    code did not account for, even while testing. They definitely should have 
-    added tests with invalid/malformed input files to make sure the error 
-    handling was graceful.
+    note: |
+      Even though the vulnerability was not severe enough to be actively 
+      abused, it was still a scenario that the developer of the native journal 
+      code did not account for, even while testing. They definitely should have 
+      added tests with invalid/malformed input files to make sure the error 
+      handling was graceful.
   least_privilege:
     applies: false
     note:
@@ -433,17 +453,19 @@ lessons:
     note:
   distrust_input:
     applies: true
-    note: Similarly to the methods for achieving defense in depth, the 
-    assumption that user log files would be correct all the time was unsafe.
+    note: |
+      Similarly to the methods for achieving defense in depth, the 
+      assumption that user log files would be correct all the time was unsafe.
   security_by_obscurity:
     applies: false
     note:
   serial_killer:
     applies: true
-    note: Serialization was a necessary risk for the sake of being able to 
-    properly test functionality in other parts of systemd. In an ideal world, 
-    the user would not need to manually specify and/or move around what log 
-    files are needed for testing.
+    note: |
+      Serialization was a necessary risk for the sake of being able to 
+      properly test functionality in other parts of systemd. In an ideal world, 
+      the user would not need to manually specify and/or move around what log 
+      files are needed for testing.
   environment_variables:
     applies: false
     note:
@@ -486,18 +508,18 @@ mistakes:
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
   answer: |
-  This vulnerability most likely came from a mistake in planning, which 
-  is totally valid for a project that grew as much as systemd. It seems that 
-  allowing the user to have some control over the logging subsystem was an 
-  afterthought, meaning that the original logging functionality was not 
-  adequately prepared to handle the extra complexity and error that comes 
-  with any user input. 
-  An ideal fix to the solution would have been eliminating 
-  the assumption in the preexisting logging system that all log messages would 
-  be formatted correctly. Despite that, restricting where logging input files 
-  are allowed to come from also works as a mitigation in this scenario, 
-  because it is unlikely that the average user would need to use the feature 
-  in the first place.
+    This vulnerability most likely came from a mistake in planning, which 
+    is totally valid for a project that grew as much as systemd. It seems that 
+    allowing the user to have some control over the logging subsystem was an 
+    afterthought, meaning that the original logging functionality was not 
+    adequately prepared to handle the extra complexity and error that comes 
+    with any user input. 
+    An ideal fix to the solution would have been eliminating 
+    the assumption in the preexisting logging system that all log messages would 
+    be formatted correctly. Despite that, restricting where logging input files 
+    are allowed to come from also works as a mitigation in this scenario, 
+    because it is unlikely that the average user would need to use the feature 
+    in the first place.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -514,9 +536,10 @@ CWE_instructions: |
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
 CWE: 399
-CWE_note: Resource management error- there was a lack of handling for 
-gracefully continuing logging after error due to user input. In direct 
-relation to the fix, improper resource name/file restrictions also applies.
+CWE_note: |
+  Resource management error- there was a lack of handling for 
+  gracefully continuing logging after error due to user input. In direct 
+  relation to the fix, improper resource name/file restrictions also applies.
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -130,7 +130,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 11
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?

--- a/cves/CVE-2013-4393.yml
+++ b/cves/CVE-2013-4393.yml
@@ -86,7 +86,7 @@ fixes_instructions: |
   Place any notes you would like to make in the notes field.
 fixes:
 - commit: 1dfa7e79a60de680086b1d93fcc3629b463f58bd
-  note: |
+  :note: |
   Based on patch mentioned in https://cgit.freedesktop.org/systemd/systemd/commit/?id=1dfa7e79a60de680086b1d93fcc3629b463f58bd
   This fix makes it so predefined log data can only come from trusted logging 
   directories in the Linux OS (such as /tmp/). This also means only people with 


### PR DESCRIPTION
When systemd logging is set to get native messages from a file, local users can craft the file to exploit a denial of service vulnerability for the logging service.