### PR TITLE
CVE-2018-16864

### DIFF
--- a/cves/CVE-2018-16864.yml
+++ b/cves/CVE-2018-16864.yml
@@ -148,9 +148,9 @@ discovered:
     findings to Red Hat Product Security. A brief summary of their discovery and
     timeline can be found here:
     https://www.qualys.com/2019/01/09/system-down/system-down.txt
-  automated:
-  contest:
-  developer:
+  automated: false
+  contest: false
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -309,7 +309,7 @@ discussion:
 
   discussed_as_security: false
   any_discussion: false
-  note:
+  note: The vulnerability was fixed very quickly after being discovered
 vouch:
   question: |
     Was there any part of the fix that involved one person vouching for 

--- a/cves/CVE-2018-16864.yml
+++ b/cves/CVE-2018-16864.yml
@@ -58,7 +58,7 @@ description_instructions: |
 description: |  
   Early versions of systemd contained an exploit in systemd-journald - a service
   which collects and stores logging data, making use of the function syslog().
-  Certain programs thats made syslog() function calls could crash systemd if an
+  Certain programs that made syslog() function calls could crash systemd if an
   extremely long number of command line arguments were given. This crash was
   caused by poor memory allocation.
 bounty_instructions: |
@@ -108,7 +108,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 8
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?
@@ -266,7 +266,7 @@ sandbox:
   answer: true
   note: |  
     By crashing systemd, an attacker could potentially confuse the memory
-    allocation done in jounrald to write to memory they were not supposed to.
+    allocation done in journald to write to memory they were not supposed to.
     This is known as a Stack Clash vulnerability, and is considered a sandboxing
     violation.
 ipc:
@@ -342,7 +342,7 @@ stacktrace:
   note: |  
     There were no full stacktraces pointing to specific files, only an error
     message indicating a segfault in the journald service. The bugfixes were
-    within the journald subsystem, however.
+    within the journald subsystem.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?

--- a/cves/CVE-2018-16864.yml
+++ b/cves/CVE-2018-16864.yml
@@ -19,14 +19,14 @@ curated_instructions: |
   This will enable additional editorial checks on this file to make sure you 
   fill everything out properly. If you are a student, we cannot accept your work
   as finished unless curated is properly updated. 
-curation_level: 0
+curation_level: 1
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that
   the CVE was created.  Leave blank if no date is given.
 
   Please enter your date in YYYY-MM-DD format.
-reported_date:
+reported_date: 2018-11-26
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE date.
@@ -34,11 +34,11 @@ announced_instructions: |
   This is not the same as published date in the NVD - that is below.
 
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: 2019-01-09
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: 2019-01-11
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -55,7 +55,12 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |  
+  Early versions of systemd contained an exploit in systemd-journald - a service
+  which collects and stores logging data, making use of the function syslog().
+  Certain programs thats made syslog() function calls could crash systemd if an
+  extremely long number of command line arguments were given. This crash was
+  caused by poor memory allocation.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -70,7 +75,7 @@ bugs_instructions: |
 
   For systemd, this is typically their GitHub issues, but could also include 
   bugs from other databases. Put a URL instead of a single number.
-bugs: []
+bugs: ['https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2018-16864']
 fixes_instructions: |
   Please put the commit hash in "commit" below.
 
@@ -81,8 +86,6 @@ fixes_instructions: |
 fixes:
 - commit: 084eeb865ca63887098e0945fb4e93c852b91b0f
   note: https://github.com/systemd/systemd/commit/084eeb865ca63887098e0945fb4e93c852b91b0f
-- commit:
-  note:
 vcc_instructions: |
   The vulnerability-contributing commits.
 
@@ -96,32 +99,8 @@ vcc_instructions: |
 
   Place any notes you would like to make in the notes field.
 vccs:
-- commit: c004493cdefc1f43a3956ca529e8070f8d70be56
-  :note: Discovered automatically by archeogit.
-- commit: 11c3a36649e5e5e77db499c92f3cdcbd619efd3a
-  :note: Discovered automatically by archeogit.
-- commit: e6a7ec4b8e33f38f578e12af9ae9ca7ddde80aac
-  :note: Discovered automatically by archeogit.
-- commit: 9aa820231414baa28e6bf02a033932cb69ff6b8b
-  :note: Discovered automatically by archeogit.
-- commit: f45b8015513d38ee5f7cc361db9c5b88c9aae704
-  :note: Discovered automatically by archeogit.
-- commit: ea5cc2a8f65535a9b3f8ba39a8df13a0c770f41d
-  :note: Discovered automatically by archeogit.
-- commit: 3c171f0b1ec3ce1b98777cca7330727b9ebfd17d
-  :note: Discovered automatically by archeogit.
-- commit: 92e92d71faea0f107312f296b7756cc04281ba99
-  :note: Discovered automatically by archeogit.
-- commit: d14bcb4ea7b71f475fbf05ecca568b534f419b98
-  :note: Discovered automatically by archeogit.
-- commit: 22e3a02b9d618bbebcf987bc1411acda367271ec
-  :note: Discovered automatically by archeogit.
-- commit: 968f319679d9069af037240d0c3bcd126181cdac
-  :note: Discovered automatically by archeogit.
-- commit: d025f1e4dca8fc1436aff76f9e6185fe3e728daa
-  :note: Discovered automatically by archeogit.
-- commit: 19cace379f3f680d3201cd257ab3ca6708b2d45d
-  :note: Discovered automatically by archeogit.
+- commit: ae018d9bc900d6355dea4af05119b49c67945184
+  :note: The addition of strappenda() at line 558 was identified to be the VCC.
 upvotes_instructions: |
   For the first round, ignore this upvotes number.
 
@@ -144,9 +123,9 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
+  code: false
   code_answer:
-  fix:
+  fix: false
   fix_answer:
 discovered:
   question: |
@@ -162,7 +141,13 @@ discovered:
 
     If there is no evidence as to how this vulnerability was found, then please
     explain where you looked.
-  answer:
+  answer: |  
+    A team of researchers from Qualys Research Labs did a third-party security
+    advisory on systemd-journald and accidentally found the vulnerability while
+    testing a different vulnerability (CVE-2018-14634). They reported their
+    findings to Red Hat Product Security. A brief summary of their discovery and
+    timeline can be found here:
+    https://www.qualys.com/2019/01/09/system-down/system-down.txt
   automated:
   contest:
   developer:
@@ -182,8 +167,11 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: |  
+    The vulnerability was simply caused by a large input via command line
+    argument. This is certainly an input that could be automatically tested via a
+    fuzzer
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example, the POSIX
@@ -200,8 +188,8 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  note:
-  answer:
+  note: No mention of spec violations found
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in? These are subsystems WITHIN systemd
@@ -230,8 +218,9 @@ subsystem:
         name: ["subsystemA", "subsystemB"] # ok
         name: subsystemA # also ok
 
-  name:
-  note:
+  name: journald
+  note: |  
+    journald is a subsystem responsible for collecting and storing logging data
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -239,8 +228,10 @@ interesting_commits:
     Use this to specify any commits you think are notable in some way, and
     explain why in the note.
   commits:
-  - commit:
-    note:
+  - commit: ac2e41f5103ce2c679089c4f8fb6be61d7caec07
+    note: |  
+       While the vulnerability was introduced in 2013, this change made the
+       vulnerability exploitable, according to the discoverers at Qualys.
   - commit:
     note:
 i18n:
@@ -255,8 +246,10 @@ i18n:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |  
+    There is nothing in the vulnerability relating to internationalizations
+    since the vulnerability is caused by the size of input, not content.
 sandbox:
   question: |
     Did this vulnerability violate a sandboxing feature that the system
@@ -270,8 +263,12 @@ sandbox:
     Answer should be true or false
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: |  
+    By crashing systemd, an attacker could potentially confuse the memory
+    allocation done in jounrald to write to memory they were not supposed to.
+    This is known as a Stack Clash vulnerability, and is considered a sandboxing
+    violation.
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -282,8 +279,8 @@ ipc:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: true
+  note: The exploit allows writing to memory that other processes use
 discussion:
   question: |
     Was there any discussion surrounding this?
@@ -310,8 +307,8 @@ discussion:
     Put any links to disagreements you found in the notes section, or any other
     comment you want to make.
 
-  discussed_as_security:
-  any_discussion:
+  discussed_as_security: false
+  any_discussion: false
   note:
 vouch:
   question: |
@@ -325,8 +322,8 @@ vouch:
 
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of what your answer was.
-  answer:
-  note:
+  answer: false
+  note: No upvotes or public discussion found surrounding the bugfix
 stacktrace:
   question: |
     Are there any stacktraces in the bug reports? 
@@ -340,9 +337,12 @@ stacktrace:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  any_stacktraces:
-  stacktrace_with_fix:
-  note:
+  any_stacktraces: false
+  stacktrace_with_fix: false
+  note: |  
+    There were no full stacktraces pointing to specific files, only an error
+    message indicating a segfault in the journald service. The bugfixes were
+    within the journald subsystem, however.
 forgotten_check:
   question: |
     Does the fix for the vulnerability involve adding a forgotten check?
@@ -361,8 +361,11 @@ forgotten_check:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |  
+    The fix mainly revolved around changing where commandline parameters were
+    being stored: from stack memory to heap memory. The fix did not involve
+    adding forgotten checks
 order_of_operations:
   question: |
     Does the fix for the vulnerability involve correcting an order of 
@@ -374,8 +377,10 @@ order_of_operations:
     Answer must be true or false.
     Write a note about how you came to the conclusions you did, regardless of
     what your answer was.
-  answer:
-  note:
+  answer: false
+  note: |  
+    The fix was about the operations themselves (where in memory to save certain
+    data) and not the order of those operations.
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -404,8 +409,10 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: |  
+      The program trusted that commandline input would be of a reasonable size,
+      not big enough to crash stack allocated memory.
   security_by_obscurity:
     applies:
     note:
@@ -422,8 +429,11 @@ lessons:
     applies:
     note:
   complex_inputs:
-    applies:
-    note:
+    applies: true
+    note: |  
+      The size of the commandline input was certainly a complex factor that
+      developers did not initially take into consideration. This just proves one
+      of the many ways input can be complex.
 mistakes:
   question: |
     In your opinion, after all of this research, what mistakes were made that
@@ -453,7 +463,12 @@ mistakes:
 
     Write a thoughtful entry here that people in the software engineering
     industry would find interesting.
-  answer:
+  answer: |  
+    The vulnerability was mainly the result of a planning error from the
+    developers. They did not forsee that commandline input being saved in stack
+    memory instead of heap memory would lead to a potential exploit due to its
+    excessive size. In general, heap memory is larger than stack memory so it
+    can hold larger points of data.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -469,8 +484,8 @@ CWE_instructions: |
     CWE: ["123", "456"] # this is ok
     CWE: [123, 456]     # also ok
     CWE: 123            # also ok
-CWE:
-CWE_note:
+CWE: 789
+CWE_note: 
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it.
   If the report mentions a nickname, use that.

--- a/cves/CVE-2018-16864.yml
+++ b/cves/CVE-2018-16864.yml
@@ -108,7 +108,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes: 8
+upvotes: 7
 unit_tested:
   question: |
     Were automated unit tests involved in this vulnerability?

--- a/cves/CVE-2018-16864.yml
+++ b/cves/CVE-2018-16864.yml
@@ -232,8 +232,6 @@ interesting_commits:
     note: |  
        While the vulnerability was introduced in 2013, this change made the
        vulnerability exploitable, according to the discoverers at Qualys.
-  - commit:
-    note:
 i18n:
   question: |
     Was the feature impacted by this vulnerability about internationalization


### PR DESCRIPTION
Pull request for CVE-2018-16864, a vulnerability relating to stack vs heap memory allocation found in the systemd-journald subsystem.
